### PR TITLE
Finished translation of Installation page

### DIFF
--- a/src/content/learn/installation.md
+++ b/src/content/learn/installation.md
@@ -1,25 +1,25 @@
 ---
-title: Installation
+title: Встановлення
 ---
 
 <Intro>
 
-React has been designed from the start for gradual adoption. You can use as little or as much React as you need. Whether you want to get a taste of React, add some interactivity to an HTML page, or start a complex React-powered app, this section will help you get started.
+Від самого початку React був спроєктований для поступового впровадження. Ви можете використовувати стільки React-у, скільки вам потрібно. Бажаєте ознайомитися з React, додати трохи інтерактивності до HTML-сторінки чи створити складний React-застосунок — цей розділ допоможе вам почати роботу.
 
 </Intro>
 
 <YouWillLearn isChapter={true}>
 
-* [How to start a new React project](/learn/start-a-new-react-project)
-* [How to add React to an existing project](/learn/add-react-to-an-existing-project)
-* [How to set up your editor](/learn/editor-setup)
-* [How to install React Developer Tools](/learn/react-developer-tools)
+* [Як почати новий React-проєкт](/learn/start-a-new-react-project)
+* [Як інтегрувати React в існуючий проєкт](/learn/add-react-to-an-existing-project)
+* [Як налаштувати редактор коду](/learn/editor-setup)
+* [Як встановити інструменти React розробника](/learn/react-developer-tools)
 
 </YouWillLearn>
 
-## Try React {/*try-react*/}
+## Спробувати React {/*try-react*/}
 
-You don't need to install anything to play with React. Try editing this sandbox!
+Не потрібно нічого встановлювати, щоб погратися з React. Спробуйте відредагувати код у цій пісочниці!
 
 <Sandpack>
 
@@ -35,23 +35,23 @@ export default function App() {
 
 </Sandpack>
 
-You can edit it directly or open it in a new tab by pressing the "Fork" button in the upper right corner.
+Ви можете редагувати його прямо на цій сторінці або відкрити у новій вкладці, натиснувши кнопку "Fork" у верхньому правому куті.
 
-Most pages in the React documentation contain sandboxes like this. Outside of the React documentation, there are many online sandboxes that support React: for example, [CodeSandbox](https://codesandbox.io/s/new), [StackBlitz](https://stackblitz.com/fork/react), or [CodePen.](https://codepen.io/pen?&editors=0010&layout=left&prefill_data_id=3f4569d1-1b11-4bce-bd46-89090eed5ddb)
+Більшість сторінок у документації React містять схожі пісочниці. Водночас існує багато інших онлайн-пісочниць з підтримкою React, наприклад: [CodeSandbox](https://codesandbox.io/s/new), [StackBlitz](https://stackblitz.com/fork/react) або [CodePen.](https://codepen.io/pen?&editors=0010&layout=left&prefill_data_id=3f4569d1-1b11-4bce-bd46-89090eed5ddb)
 
-### Try React locally {/*try-react-locally*/}
+### Спробувати React локально {/*try-react-locally*/}
 
-To try React locally on your computer, [download this HTML page.](https://gist.githubusercontent.com/gaearon/0275b1e1518599bbeafcde4722e79ed1/raw/db72dcbf3384ee1708c4a07d3be79860db04bff0/example.html) Open it in your editor and in your browser!
+Щоб спробувати React локально на вашому комп'ютері, [завантажте цю HTML-сторінку.](https://gist.githubusercontent.com/gaearon/0275b1e1518599bbeafcde4722e79ed1/raw/db72dcbf3384ee1708c4a07d3be79860db04bff0/example.html) Відкрийте її у редакторі та браузері!
 
-## Start a new React project {/*start-a-new-react-project*/}
+## Почати новий React-проєкт {/*start-a-new-react-project*/}
 
-If you want to build an app or a website fully with React, [start a new React project.](/learn/start-a-new-react-project)
+Якщо ви хочете створити застосунок або вебсайт за допомогою React, [почніть новий React-проєкт.](/learn/start-a-new-react-project)
 
-## Add React to an existing project {/*add-react-to-an-existing-project*/}
+## Інтегрувати React в існуючий проєкт {/*add-react-to-an-existing-project*/}
 
-If want to try using React in your existing app or a website, [add React to an existing project.](/learn/add-react-to-an-existing-project)
+Якщо ви хочете використати React у власному застосунку або вебсайті, [інтегруйте React в існуючий проєкт.](/learn/add-react-to-an-existing-project)
 
-## Next steps {/*next-steps*/}
+## Подальші кроки {/*next-steps*/}
 
-Head to the [Quick Start](/learn) guide for a tour of the most important React concepts you will encounter every day.
+Відвідайте розділ ["Швидкий старт"](/learn), щоб ознайомитися з найважливішими повсякденними концепціями React.
 


### PR DESCRIPTION
- Added translation of Installation page
  - `add React to an existing project` and `React Developer Tools` phrases were translated similar to existing pages of the same name
  - `Next Steps` was translated similar to the one in Quick Start - `Подальші кроки`. Although it can be changed to `Наступні кроки` or `Далі` in both pages.

Also:
- some excessive use of `your` was omitted as it's unnatural in Ukrainian
- `to get a taste of` was translated as `ознайомитися з`, 'cause I didn't find if it's okay to use word-by-word translation for this idiom
- `Fork` as name button was left untouched until we translate common UI words including ones for sandbox
- non-breakable space was not used before the dash, but I think, that we want such rule in project, as I've already encountered issue with dash being on new line.